### PR TITLE
[FEAT] error page 추가

### DIFF
--- a/src/main/resources/templates/error/4xx.html
+++ b/src/main/resources/templates/error/4xx.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/fragments/header.html :: header"></head>
+<body>
+<header th:replace="/fragments/body-header.html :: body-header (${user.id}, ${user.name}, ${user.userImageUrl})"></header>
+
+<section id="section" class="section-with-bg">
+    <div class="text-center card w-50">
+        <div class="card-body">
+            <div class="section-header">
+                <br>
+                <h2>페이지를 찾을 수 없습니다!</h2>
+            </div>
+            <div class="m-3">
+                <div>찾을 수 없는 페이지 입니다.</div>
+                <br>
+                <div>요청하신 페이지의 경로를 다시 한번 확인해주세요!</div>
+            </div>
+            <div class="m-3">
+                <a href="/home" class="btn btn-dark">home</a>
+            </div>
+        </div>
+    </div>
+</section>
+
+<footer th:replace="/fragments/body-footer.html :: body-footer"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/fragments/header.html :: header"></head>
+<body>
+<header th:replace="/fragments/body-header.html :: body-header (${user.id}, ${user.name}, ${user.userImageUrl})"></header>
+
+<section id="section" class="section-with-bg">
+    <div class="section-header">
+        <br>
+        <h2>서버에 문제가 발생하였습니다!</h2>
+    </div>
+</section>
+
+<footer th:replace="/fragments/body-footer.html :: body-footer"></footer>
+</body>
+</html>


### PR DESCRIPTION
4xx로 server에 예외가 발생할 경우 처리할 예외 페이지를 작성

![image](https://user-images.githubusercontent.com/59357153/120769667-504dc500-c558-11eb-9b6a-03b7b0ca5974.png)
위와 같이 mapping 되지 않는 url로 요청을 보낼 경우 

아래와 같이 찾을 수 없는 페이지임을 직관적으로 알려줍니다.
![image](https://user-images.githubusercontent.com/59357153/120769474-21cfea00-c558-11eb-8831-86ff2e75449d.png)
최대한 간략하게 작성하였습니다!

추가적으로 5xx 에러의 경우 server자체가 다운될 수 있는 것을 고려하여 nginx를 활용하여 외부에서 해당 페이지를 설정하는 방법을 생각해보면 좋을 것 같아요! 다양한 의견 부탁드립니다.